### PR TITLE
Add `visibility` slot to Symbol model

### DIFF
--- a/abi3info/models.py
+++ b/abi3info/models.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal, Union
 
+# values taken from the GCC/Clang manual.
+Visibility = Literal["default", "hidden", "internal", "protected"]
+
 
 @dataclass(frozen=True, eq=False, unsafe_hash=True)
 class Symbol:
@@ -23,6 +26,11 @@ class Symbol:
     """
     The symbol's underlying name. This may not correspond to an actual symbol
     in a binary without platform-specific normalization.
+    """
+    visibility: Visibility | None = None
+    """
+    The symbol's visibility in the shared object file, or None if it could not
+    be determined.
     """
 
     @property


### PR DESCRIPTION
In preparation for the visibility-based selective flagging of CPython symbols marked as `static inline`.

cf https://github.com/trailofbits/abi3audit/issues/85.