### PR TITLE
Change visibility values to actually observed visibilities

### DIFF
--- a/abi3info/models.py
+++ b/abi3info/models.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal, Union
 
-# values taken from the GCC/Clang manual.
-Visibility = Literal["default", "hidden", "internal", "protected"]
+# a best-effort taxonomy for shared object file symbols across all platforms.
+Visibility = Literal["local", "global", "weak"]
 
 
 @dataclass(frozen=True, eq=False, unsafe_hash=True)


### PR DESCRIPTION
The previous value set was the flag value set of clang/gcc, but that does not match what we observe in practice from outputs like `nm -gC` or manpages like e.g. on ELF.

The new values are local (for hidden symbols), global (for symbols visible across files), and weak (for weak symbols, possibly not available on all platforms).